### PR TITLE
chore: add plotter as dev-only dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spfunc"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["doraneko94 <shuntaro94@gmail.com>"]
 edition = "2021"
 
@@ -21,9 +21,9 @@ doctest = false
 num-complex = "0.4.6"
 num-traits = "0.2.19"
 cauchy = "0.4.0"
-plotters = "0.3.7"
 
 [dev-dependencies]
 criterion = "0.6.0"
 rand = "0.9.1"
 rand_distr = "0.5.1"
+plotters = "0.3.7"


### PR DESCRIPTION
Hey, I'd like to move `plotters` dependency which is used only in examples to `[dev-dependencies]`.

The compilation with plotters needs to compile 78 crates and it's only 22 without it.